### PR TITLE
Update egui/eframe to 0.23.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui-modal"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "MIT"
 description = "a modal library for egui"
@@ -11,7 +11,7 @@ authors = ["n00kii"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-egui = "0.22.0"
+egui = "0.23.0"
 
 [dev-dependencies]
-eframe  = "0.22.0"
+eframe  = "0.23.0"


### PR DESCRIPTION
I also bumped the version of this library, but I'm happy to undo that if you prefer. I seemingly need a new release of this for compatibility with the new release of egui and eframe.