### PR TITLE
Update egui & eframe to 0.24.0, clippy fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["n00kii"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-egui = "0.23.0"
+egui = "0.24.0"
 
 [dev-dependencies]
-eframe  = "0.23.0"
+eframe  = "0.24.0"

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -472,11 +472,8 @@ impl Modal {
                             self.close();
                         }
                     }
-                    ui.painter().rect_filled(
-                        screen_rect,
-                        Rounding::none(),
-                        self.style.overlay_color,
-                    );
+                    ui.painter()
+                        .rect_filled(screen_rect, Rounding::ZERO, self.style.overlay_color);
                 });
 
             ctx_clone.move_to_top(area_resp.response.layer_id);
@@ -555,11 +552,11 @@ impl Modal {
                     self.title(ui, title)
                 }
                 self.frame(ui, |ui| {
-                    if !modal_data.body.is_some() {
+                    if modal_data.body.is_none() {
                         if let Some(icon) = modal_data.icon {
                             self.icon(ui, icon)
                         }
-                    } else if !modal_data.icon.is_some() {
+                    } else if modal_data.icon.is_none() {
                         if let Some(body) = modal_data.body {
                             self.body(ui, body)
                         }


### PR DESCRIPTION
Update `egui` and `eframe` to 0.24.0, apply 2 clippy fixes, replace usage of deprecated `Rounding::none()` function with `Rounding::ZERO`