### PR TITLE
Update egui & eframe to 0.24.1, bump semver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.1
+ - update egui -> `0.24.1`
+
 # 0.3.0
  - deprecate `Modal::open_dialog` (use `Modal::dialog`, `DialogBuilder::with_*` and `DialogBuilder::show` functions instead) 
  - update egui -> `0.24.0`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui-modal"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT"
 description = "a modal library for egui"
@@ -11,7 +11,7 @@ authors = ["n00kii"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-egui = "0.24.0"
+egui = "0.24.1"
 
 [dev-dependencies]
-eframe  = "0.24.0"
+eframe  = "0.24.1"


### PR DESCRIPTION
Updates egui and eframe to 0.24.1

Changelogs: [egui](https://github.com/emilk/egui/blob/master/CHANGELOG.md#0241---2023-11-30---bug-fixes), [eframe](https://github.com/emilk/egui/blob/master/crates/eframe/CHANGELOG.md#0241---2023-11-30)