### PR TITLE
Allow modals to have a window frame and title

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -11,6 +11,7 @@ struct ExampleApp {
     include_body: bool,
     include_buttons: bool,
     close_on_outside_click: bool,
+    with_window_title: bool,
 
     dialog_icon: Option<Icon>,
 }
@@ -27,6 +28,7 @@ impl Default for ExampleApp {
             include_body: true,
             include_buttons: true,
             close_on_outside_click: false,
+            with_window_title: false,
 
             dialog_icon: Some(Icon::Info),
         }
@@ -116,9 +118,24 @@ impl eframe::App for ExampleApp {
                         self.close_on_outside_click = !self.close_on_outside_click
                     };
                 });
-                ui.checkbox(&mut self.include_title, "include title");
+                ui.horizontal(|ui| {
+                    ui.checkbox(&mut self.include_title, "include title");
+                    if self.modal_style.window_title.is_some() {
+                        ui.label("(this looks bad if you have a window title)");
+                    }
+                });
                 ui.checkbox(&mut self.include_body, "include body");
                 ui.checkbox(&mut self.include_buttons, "include buttons");
+                ui.checkbox(&mut self.with_window_title, "set window title");
+                if self.with_window_title {
+                    let window_title = self
+                        .modal_style
+                        .window_title
+                        .get_or_insert_with(|| "i'm a title".to_string());
+                    ui.text_edit_singleline(window_title);
+                } else {
+                    self.modal_style.window_title = None;
+                }
                 ui.separator();
                 egui::Grid::new("options_grid")
                     .min_col_width(200.)

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -138,6 +138,8 @@ pub struct ModalStyle {
 
     /// The alignment of text inside the body
     pub body_alignment: Align,
+    /// Window title, title bar will only be shown if this is [Some]
+    pub window_title: Option<String>,
 }
 
 impl ModalState {
@@ -186,6 +188,7 @@ impl Default for ModalStyle {
             default_width: None,
 
             body_alignment: Align::Min,
+            window_title: None,
         }
     }
 }
@@ -507,12 +510,18 @@ impl Modal {
                 .default_height
                 .map_or(window_id, |h| window_id.with(h.to_string()));
 
-            let mut window = Window::new("")
-                .id(window_id)
-                .open(&mut modal_state.is_open)
-                .title_bar(false)
-                .anchor(Align2::CENTER_CENTER, [0., 0.])
-                .resizable(false);
+            let mut window = Window::new(
+                self.style
+                    .window_title
+                    .as_ref()
+                    .map(|t| t.as_str())
+                    .unwrap_or(""),
+            )
+            .id(window_id)
+            .open(&mut modal_state.is_open)
+            .title_bar(self.style.window_title.is_some())
+            .anchor(Align2::CENTER_CENTER, [0., 0.])
+            .resizable(false);
 
             let recalculating_height =
                 self.style.default_height.is_some() && modal_state.last_frame_height.is_none();
@@ -529,10 +538,11 @@ impl Modal {
 
             if let Some(inner_response) = response {
                 ctx_clone.move_to_top(inner_response.response.layer_id);
-                if recalculating_height {
-                    let mut modal_state = ModalState::load(&self.ctx, self.id);
-                    modal_state.last_frame_height = Some(inner_response.response.rect.height());
-                    modal_state.save(&self.ctx, self.id);
+                if recalculating_height || !modal_state.is_open {
+                    let mut new_modal_state = ModalState::load(&self.ctx, self.id);
+                    new_modal_state.last_frame_height = Some(inner_response.response.rect.height());
+                    new_modal_state.is_open = modal_state.is_open;
+                    new_modal_state.save(&self.ctx, self.id);
                 }
             }
         }


### PR DESCRIPTION
https://github.com/n00kii/egui-modal/assets/108888572/0d4e6b64-c65c-4865-b6e8-e73e6f185975

This allows for modal to have an egui window border with a custom title and an ❌ button to close the modal 

* update example
* add `window_title` field to `ModalStyle`